### PR TITLE
Use setImmediate to start new call stack

### DIFF
--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -162,7 +162,7 @@ module.exports = function(grunt) {
       grunt.file.write(getName(config.output, basename), html);
     });
 
-    setImmediate(done);
+    process.nextTick(done);
 
   });
 };


### PR DESCRIPTION
This fixes "Maximum call stack size exceeded errors" when compiling thousands of templates.
