### PR TITLE
getBasename function supports filenames with multiple '.' in extension

### DIFF
--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
       basename = filename.split('/').pop().split('.');
       basename.pop();
     }
-    return basename.toString();
+    return basename.join('.');
   };
 
   var getName = function(filename, basename) {


### PR DESCRIPTION
Using join intend of toString allows this package to support src file names with multiple '.' (periods) in the filename.

With config

```
template: "templates/*.hbs"
output: "www/*"
```

and template dir containing:

```
config.xml.hbs
index.html.hbs
```

Before PR:
  wrote files: config,xml and index,html (notice the bad comma)

After PR:
    wrote files: config.xml and index.html (looks good!)

Basename will always be an array - using join('.') here instead toString() is fine.
