### PR TITLE
Local template data should merge onto global template data

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "handlebars": ">= 1",
-    "lodash.assign": ">= 2"
+    "lodash.merge": ">= 2"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -10,7 +10,7 @@
 
 module.exports = function(grunt) {
   var handlebars = require('handlebars');
-  var extend = require('lodash.assign');
+  var merge = require('lodash.merge');
 
   /* Normalizes the input so that
    * it is always an array for the
@@ -106,24 +106,26 @@ module.exports = function(grunt) {
   };
 
   var mergeJson = function(source, globals) {
-    var json, fragment;
+    var json = {}, fragment;
 
-    globals.forEach(function (globals) {
-      if (!grunt.file.exists(globals))
-        grunt.log.error("JSON file " + globals + " not found.");
+    globals.forEach(function (global) {
+      if (!grunt.file.exists(global))
+        grunt.log.error("JSON file " + global + " not found.");
       else {
         try {
-          fragment = grunt.file.readJSON(globals);
+          fragment = grunt.file.readJSON(global);
         }
         catch (e) {
           grunt.fail.warn(e);
         }
-        if (typeof(source) !== 'object') {
-          source = fragment;
-        }
-        json = extend(source, fragment);
+        merge(json, fragment);
       }
     });
+
+    if (typeof(source) === 'object') {
+      merge(json, source);
+    }
+
     return json;
   };
 

--- a/test/globals/info.json
+++ b/test/globals/info.json
@@ -1,3 +1,7 @@
 {
-    "author": "Written by Mr. HelloWorld"
+    "templateName": "infoTemplate",
+    "author": "Written by Mr. HelloWorld",
+    "textspec": {
+        "hi": "Goodbye from info.json"
+    }
 }

--- a/test/globals/textspec.json
+++ b/test/globals/textspec.json
@@ -1,4 +1,5 @@
 {
+    "templateName": "textspecTemplate",
     "textspec": {
         "hi": "Hello from textspec.json"
     }


### PR DESCRIPTION
Currently, when using templateData and globals, properties from each globals object blindly overwrite the corresponding properties on the templateData object, and if the property is itself an object you will lose any sub-properties of that object.

Surely the desired method is for templateData objects to be gracefully merged into global objects, preserving all properties and sub-properties that have not been re-defined.
