### PR TITLE
add provided handlebars feature

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ These people have gone out of their way to add value to this little tool.
 - Martin Götte [github](https://github.com/goette) [twitter](https://twitter.com/mrtngtt)
 - Matthew Galizia [github](https://github.com/mattcg) [twitter](https://twitter.com/mcaruanagalizia)
 - Scott Timmins [github](https://github.com/stimmins)
+- Anders D. Johnson [github](https://github.com/adjohnson916) [twitter](https://twitter.com/adjohnson916) [website](http://andrz.me)

--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -133,6 +133,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('compile-handlebars', 'Compile Handlebars templates ', function() {
     var fs = require('fs');
     var config = this.data;
+    handlebars = config.handlebars || handlebars;
     var templates = getConfig(config.template);
     var templateData = config.templateData;
     var helpers = getConfig(config.helpers);


### PR DESCRIPTION
Adds support for an optional config property to provide your own handlebars instance. This allows user to require a different version of handlebars, to register own helpers, partials, settings, etc.  Better interoperability with other modules, especially those that require passing a handlebars instance such as [handlebars-helpers](https://github.com/assemble/handlebars-helpers).
