### PR TITLE
Allow plain objects in "globals" option

### DIFF
--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -99,7 +99,7 @@ module.exports = function(grunt) {
     var json = {}, fragment;
 
     globals.forEach(function (global) {
-      if (grunt.util.kindOf(global) == 'string') {
+      if (grunt.util.kindOf(global) === 'string') {
         if (!grunt.file.exists(global)) {
           grunt.log.error("JSON file " + global + " not found.");
         }


### PR DESCRIPTION
Right now globals option support just list of json files.

```
'compile-handlebars': {
    all: {
        ...
        globals: ['file1.json', 'file2.json']
    }
}
```

This pull request allows to provide plain JS objects for globals as well.

```
'compile-handlebars': {
    all: {
        ...
        globals: [
            'file1.json', 
            'file2.json',
            {
                property1: 'value1',
                property2: 'value2'
            }
        ]
    }
}
```
