### PR TITLE
Refactor to use Grunt file object

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -150,6 +150,13 @@ module.exports = function(grunt) {
           dest: 'tmp/concatGlobbed.html'
         }],
         templateData: 'test/fixtures/deep/**/*.json'
+      },
+      oneTemplateToManyOutputs: {
+        files: [{
+          src: 'test/fixtures/template.handlebars',
+          dest: ['tmp/oneTemplateToManyOutputs1.html', 'tmp/oneTemplateToManyOutputs2.html']
+        }],
+        templateData: ['test/fixtures/oneTemplateToManyOutputs1.json', 'test/fixtures/oneTemplateToManyOutputs2.json']
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,67 +31,94 @@ module.exports = function(grunt) {
     // Configuration to be run (and then tested).
     'compile-handlebars': {
       allStatic: {
+        files: [{
+          src: 'test/fixtures/template.handlebars',
+          dest: 'tmp/allStatic.html'
+        }],
         preHTML: 'test/fixtures/pre-dev.html',
         postHTML: 'test/fixtures/post-dev.html',
-        template: 'test/fixtures/template.handlebars',
-        templateData: 'test/fixtures/data.json',
-        output: 'tmp/allStatic.html'
+        templateData: 'test/fixtures/data.json'
       },
       dynamicHandlebars: {
-        template: '<h1></h1>',
+        files: [{
+            src: '<h1></h1>',
+            dest: 'tmp/dynamicHandlebars.html'
+        }],
         templateData: {},
-        output: 'tmp/dynamicHandlebars.html',
         handlebars: 'node_modules/handlebars'
       },
       jsonHandlebars: {
-        template: 'test/fixtures/sweedishTemplate.json',
-        templateData: 'test/fixtures/sweedishData.json',
-        output: 'tmp/sweedish.json'
+        files: [{
+          src: 'test/fixtures/sweedishTemplate.json',
+          dest: 'tmp/sweedish.json'
+        }],
+        templateData: 'test/fixtures/sweedishData.json'
       },
       dynamicTemplate: {
+        files: [{
+            src: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
+            dest: 'tmp/dynamicTemplate.html'
+        }],
         template: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
-        templateData: 'test/fixtures/data.json',
-        output: 'tmp/dynamicTemplate.html'
+        templateData: 'test/fixtures/data.json'
       },
       dynamicTemplateData: {
-        template: 'test/fixtures/template.handlebars',
+        files: [{
+          src: 'test/fixtures/template.handlebars',
+          dest: 'tmp/dynamicTemplateData.html'
+        }],
         templateData: {
           "salutation": "Hallo",
           "punctuation": ",",
           "location": "Welt"
-        },
-        output: 'tmp/dynamicTemplateData.html'
+        }
       },
       dynamicPre: {
+        files: [{
+          src: 'test/fixtures/template.handlebars',
+          dest: 'tmp/dynamicPre.html'
+        }],
         preHTML: '<header>INLINE HEADER</header>',
-        template: 'test/fixtures/template.handlebars',
-        templateData: 'test/fixtures/data.json',
-        output: 'tmp/dynamicPre.html'
+        templateData: 'test/fixtures/data.json'
       },
       dynamicPost: {
-        postHTML: '<footer>INLINE HEADER</footer>',
-        template: 'test/fixtures/template.handlebars',
-        templateData: 'test/fixtures/data.json',
-        output: 'tmp/dynamicPost.html'
+        files: [{
+          src: 'test/fixtures/template.handlebars',
+          dest: 'tmp/dynamicPost.html'
+        }],
+        postHTML: '<footer>INLINE FOOTER</footer>',
+        templateData: 'test/fixtures/data.json'
       },
       anyArray: {
-        template: ['test/fixtures/deep/romanian.handlebars', 'test/fixtures/deep/german.handlebars'],
+        files: [{
+          src: ['test/fixtures/deep/romanian.handlebars', 'test/fixtures/deep/german.handlebars'],
+          dest: ['tmp/deep/romanian.html','tmp/deep/german.html']
+        }],
         templateData: ['test/fixtures/deep/romanian.json', 'test/fixtures/deep/german.json'],
-        output: ['tmp/deep/romanian.html','tmp/deep/german.html'],
         helpers: ['test/helpers/super_helper.js'],
         partials: ['test/fixtures/deep/shared/foo.handlebars']
       },
       globbedTemplateAndOutput: {
-        template: 'test/fixtures/deep/**/*.handlebars',
+        files: [{
+            expand: true,
+            cwd: 'test/fixtures/',
+            src: 'deep/**/*.handlebars',
+            dest: 'tmp/',
+            ext: '.html'
+        }],
         templateData: 'test/fixtures/deep/**/*.json',
-        output: 'tmp/deep/**/*.html',
         helpers: 'test/helpers/**/*.js',
         partials: 'test/fixtures/deep/shared/**/*.handlebars'
       },
       globalJsonGlobbedTemplate: {
-        template: 'test/fixtures/deep/**/*.handlebars',
+        files: [{
+            expand: true,
+            cwd: 'test/fixtures/',
+            src: 'deep/**/*.handlebars',
+            dest: 'tmp/',
+            ext: '.html'
+        }],
         templateData: 'test/fixtures/deep/**/*.json',
-        output: 'tmp/deep/**/*.html',
         helpers: 'test/helpers/**/*.js',
         partials: 'test/fixtures/deep/shared/**/*.handlebars',
         globals: [
@@ -105,20 +132,24 @@ module.exports = function(grunt) {
         ]
       },
       registerFullPath: {
-        template: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>{{> test/fixtures/deep/shared/pathTest}}',
+        files: [{
+            src: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>{{> test/fixtures/deep/shared/pathTest}}',
+            dest: 'tmp/fullPath.html'
+        }],
         templateData: {
           "salutation": "Hallo",
           "punctuation": ",",
           "location": "Welt"
         },
-        output: 'tmp/fullPath.html',
         partials: 'test/fixtures/deep/shared/**/*.handlebars',
         registerFullPath: true
       },
       concatGlobbed: {
-        template: 'test/fixtures/deep/**/*.handlebars',
-        templateData: 'test/fixtures/deep/**/*.json',
-        output: 'tmp/concatGlobbed.html'
+        files: [{
+          src: 'test/fixtures/deep/**/*.handlebars',
+          dest: 'tmp/concatGlobbed.html'
+        }],
+        templateData: 'test/fixtures/deep/**/*.json'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -34,74 +34,128 @@ Heres a few of the ways you can use it
 
 ```javascript
 'compile-handlebars': {
-    allStatic: {
-      preHTML: 'test/fixtures/pre-dev.html',
-      postHTML: 'test/fixtures/post-dev.html',
-      template: 'test/fixtures/template.handlebars',
-      templateData: 'test/fixtures/data.json',
-      output: 'tmp/allStatic.html'
-    },
-    dynamicTemplate: {
-      template: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
-      templateData: 'test/fixtures/data.json',
-      output: 'tmp/dynamicTemplate.html'
-    },
-    dynamicTemplateData: {
-      template: 'test/fixtures/template.handlebars',
-      templateData: {
-          "salutation": "Hallo",
-          "punctuation": ",",
-          "location": "Welt"
-      },
-      output: 'tmp/dynamicTemplateData.html'
-    },
-    dynamicPre: {
-      preHTML: '<header>INLINE HEADER</header>',
-      template: 'test/fixtures/template.handlebars',
-      templateData: 'test/fixtures/data.json',
-      output: 'tmp/dynamicPre.html'
-    },
-    dynamicPost: {
-      postHTML: '<footer>INLINE HEADER</footer>',
-      template: 'test/fixtures/template.handlebars',
-      templateData: 'test/fixtures/data.json',
-      output: 'tmp/dynamicPost.html'
-    },
-    allArray: {
-      template: ['test/fixtures/deep/spanish.handlebars', 'test/fixtures/deep/deeper/portuguese.handlebars'],
-      templateData: ['test/fixtures/deep/deeper/spanish.json', 'test/fixtures/deep/deeper/portuguese.json'],
-      output: ['tmp/deep/spanish.html','tmp/deep/deeper/portuguese.html'],
-      helpers: ['test/helpers/super_helper.js'],
-      partials: ['test/fixtures/deep/shared/foo.handlebars']
-   },
-    globbedTemplateAndOutput: {
-      template: 'test/fixtures/deep/**/*.handlebars',
-      templateData: 'test/fixtures/deep/**/*.json',
-      output: 'tmp/deep/**/*.html'
-    },
-    globalJsonGlobbedTemplate: {
-      template: 'test/fixtures/deep/**/*.handlebars',
-      templateData: 'test/fixtures/deep/**/*.json',
-      output: 'tmp/deep/**/*.html',
-      helpers: 'test/helpers/**/*.js',
-      partials: 'test/fixtures/deep/shared/**/*.handlebars',
-      globals: [
-        'test/globals/info.json',
-        'test/globals/textspec.json',
-        {
-          "textspec": {
-            "ps": "P.S. from Gruntfile.js"
-          }
+  allStatic: {
+    files: [{
+      src: 'test/fixtures/template.handlebars',
+      dest: 'tmp/allStatic.html'
+    }],
+    preHTML: 'test/fixtures/pre-dev.html',
+    postHTML: 'test/fixtures/post-dev.html',
+    templateData: 'test/fixtures/data.json'
+  },
+  dynamicHandlebars: {
+    files: [{
+        src: '<h1></h1>',
+        dest: 'tmp/dynamicHandlebars.html'
+    }],
+    templateData: {},
+    handlebars: 'node_modules/handlebars'
+  },
+  jsonHandlebars: {
+    files: [{
+      src: 'test/fixtures/sweedishTemplate.json',
+      dest: 'tmp/sweedish.json'
+    }],
+    templateData: 'test/fixtures/sweedishData.json'
+  },
+  dynamicTemplate: {
+    files: [{
+        src: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
+        dest: 'tmp/dynamicTemplate.html'
+    }],
+    template: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
+    templateData: 'test/fixtures/data.json'
+  },
+  dynamicTemplateData: {
+    files: [{
+      src: 'test/fixtures/template.handlebars',
+      dest: 'tmp/dynamicTemplateData.html'
+    }],
+    templateData: {
+      "salutation": "Hallo",
+      "punctuation": ",",
+      "location": "Welt"
+    }
+  },
+  dynamicPre: {
+    files: [{
+      src: 'test/fixtures/template.handlebars',
+      dest: 'tmp/dynamicPre.html'
+    }],
+    preHTML: '<header>INLINE HEADER</header>',
+    templateData: 'test/fixtures/data.json'
+  },
+  dynamicPost: {
+    files: [{
+      src: 'test/fixtures/template.handlebars',
+      dest: 'tmp/dynamicPost.html'
+    }],
+    postHTML: '<footer>INLINE FOOTER</footer>',
+    templateData: 'test/fixtures/data.json'
+  },
+  anyArray: {
+    files: [{
+      src: ['test/fixtures/deep/romanian.handlebars', 'test/fixtures/deep/german.handlebars'],
+      dest: ['tmp/deep/romanian.html','tmp/deep/german.html']
+    }],
+    templateData: ['test/fixtures/deep/romanian.json', 'test/fixtures/deep/german.json'],
+    helpers: ['test/helpers/super_helper.js'],
+    partials: ['test/fixtures/deep/shared/foo.handlebars']
+  },
+  globbedTemplateAndOutput: {
+    files: [{
+        expand: true,
+        cwd: 'test/fixtures/',
+        src: 'deep/**/*.handlebars',
+        dest: 'tmp/',
+        ext: '.html'
+    }],
+    templateData: 'test/fixtures/deep/**/*.json',
+    helpers: 'test/helpers/**/*.js',
+    partials: 'test/fixtures/deep/shared/**/*.handlebars'
+  },
+  globalJsonGlobbedTemplate: {
+    files: [{
+        expand: true,
+        cwd: 'test/fixtures/',
+        src: 'deep/**/*.handlebars',
+        dest: 'tmp/',
+        ext: '.html'
+    }],
+    templateData: 'test/fixtures/deep/**/*.json',
+    helpers: 'test/helpers/**/*.js',
+    partials: 'test/fixtures/deep/shared/**/*.handlebars',
+    globals: [
+      'test/globals/info.json',
+      'test/globals/textspec.json',
+      {
+        textspec: {
+          "ps": "P.S. from Gruntfile.js"
         }
-      ]
+      }
+    ]
+  },
+  registerFullPath: {
+    files: [{
+        src: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>{{> test/fixtures/deep/shared/pathTest}}',
+        dest: 'tmp/fullPath.html'
+    }],
+    templateData: {
+      "salutation": "Hallo",
+      "punctuation": ",",
+      "location": "Welt"
     },
-    customHandlebars: {
-      template: '<h1>{{salutation}}{{punctuation}} {{location}}</h1>',
-      templateData: 'test/fixtures/data.json',
-      output: 'tmp/dynamicTemplate.html',
-      handlebars: 'node_modules/handlebars'
-    },
-}
+    partials: 'test/fixtures/deep/shared/**/*.handlebars',
+    registerFullPath: true
+  },
+  concatGlobbed: {
+    files: [{
+      src: 'test/fixtures/deep/**/*.handlebars',
+      dest: 'tmp/concatGlobbed.html'
+    }],
+    templateData: 'test/fixtures/deep/**/*.json'
+  }
+},
 ```
 
 The available configuration options are as follows
@@ -111,7 +165,7 @@ Unless otherwise noted, all configurable values can be represented as
 * a string representing the path to a [globbed representation](http://gruntjs.com/api/grunt.file#globbing-patterns) of the files, matched up against the values resolved from the `template` configuration
 * an array of literal paths, globbed paths, or a combination of the two
 
-__`template`__ - The template fed to handlebars. In addition to the normal configurable values, it can also be an inline string representation of a template (e.g. raw html and handlebars).
+__`files`__ - A typical [grunt files object](http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically). The `src` are your handlebar templates, the `dest` is your html ouput. See the grunt documentation and the usage examples above for more info on how to use this object.
 
 __`preHTML`__ - Static text to be inserted before the compiled template
 __`postHTML`__ - Static text to be inserted after the compiled template
@@ -120,28 +174,11 @@ __`templateData` ~~ The data being fed to compiled template, in addition to the 
 * an inline string representation of a data (I don't know why you would do that though, when you can do...)
 * an inline JSON representation of a data
 
-__`output`__ - the file(s) that handlebars saves the files to. This can be
-* a string representing the path to a specific file
-* a string representing the path to a [globbed representation](http://gruntjs.com/api/grunt.file#globbing-patterns) of the files.
-* an array of literal paths, globbed paths, or a combination of the two
-
 __`globals`__ - globals that can be included, useful for when you have template specific data, but want some data available to all templates
 __`helpers`__ - handlebars helpers
 __`partials`__ - handlebars partials
 
 __`registerFullPath`__ - normally, helpers and partials are registered under their basename, rather than their path (e.g. partial at `partials/deep/awesomePartial.handlebars` is registered as `{{> awesomePartial}}`). When set to `true`, helpers and partials are registered under their full paths (e.g. {{> partials/deep/awesomePartial}}), to prevent clobbering after resolving globbed values.
-
-__`outputInInput`__ - most of the time, you define your handlebars files in one directory, and want them to be outputted into another directory. However, when you glob your all your files (`./**/*.handlebars`) this just outputs all your files to your root directory. In this case, you can add the boolean `outputInInput` to the configuration, which will output the globbed html into the same folders that the handlebar files are found. e.g, given the following configuraiton
-
-```
-  gottaGlobEmAll: {
-    template: "./**/*.handlebars",
-    templateData: {},
-    output: "./**/*.html"
-  }
-```
-
-`./foo/bar.handlebars` would output to `./bar.html`. By adding `outputInInput: true` to the configuration, it will output to `./foo/bar.html`
 
 `handlebars` - a string representing the path to an instance of handlebars (if you don't want to use the bundeled version).
 Note: This __cannot__ be `require('handlebars')`, as that creates a circular reference. You need to pass the path to the instance you want to use, i.e. `handlebars: "./node_modules/handlebars"`
@@ -161,11 +198,14 @@ When you specify templates using globs, the values from `template` are used to c
 and your configuration looks like this
 
 ```JSON
-{
-  "template": "./foo/*.handlebars",
-  "templateData": "./foo/*.json",
-  "output":  "./foo/*.html"
-}
+files: [{
+    expand: true,
+    cwd: './foo/',
+    src: '*.handlebars',
+    dest: './foo/',
+    ext: '.html'
+}],
+"templateData": "./foo/*.json",
 ```
 
 the output would be `./foo/bar.html` and `./foo/baz.html`

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ When you specify templates using globs, the values from `template` are used to c
 
 and your configuration looks like this
 
-```JSON
+```
 files: [{
     expand: true,
     cwd: './foo/',

--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Heres a few of the ways you can use it
       dest: 'tmp/concatGlobbed.html'
     }],
     templateData: 'test/fixtures/deep/**/*.json'
+  },
+  oneTemplateToManyOutputs: {
+    files: [{
+      src: 'test/fixtures/template.handlebars',
+      dest: ['tmp/oneTemplateToManyOutputs1.html', 'tmp/oneTemplateToManyOutputs2.html']
+    }],
+    templateData: ['test/fixtures/oneTemplateToManyOutputs1.json', 'test/fixtures/oneTemplateToManyOutputs2.json']
   }
 },
 ```

--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
     return [config];
   };
 
-  // Gets the final representation of the input, wether it be object, or string
+  // Gets the final representation of the input, whether it be object, or string
   var parseData = function(data, dontParse) {
     // grunt.file chokes on objects, so we check for it immiedietly
     if (typeof data === 'object') {
@@ -50,7 +50,7 @@ module.exports = function(grunt) {
 
   // Checks if the input is a glob and if so, returns the unglobbed version of the filename
   var isGlob = function(filename) {
-    if (!filename) return;
+    if (!filename || typeof filename === 'object') return;
     var match = filename.match(/[^\*]*/);
     if (match[0] !== filename) {
       return match.pop();
@@ -82,7 +82,7 @@ module.exports = function(grunt) {
     if (Array.isArray(filename)) {
       var file = filename[index];
       if (file) return file;
-      grunt.log.error('You need to assign the same number of ouputs as you do templates when using array notation.');
+      grunt.log.error('You need to assign the same number of outputs as you do templates when using array notation.');
       return;
     }
     if (typeof filename === 'object') {
@@ -134,25 +134,53 @@ module.exports = function(grunt) {
     return itShould;
   };
 
-  var getTemplates = function(templatesConfig){
-    if(Array.isArray(templatesConfig)){
-      return [].concat.apply([], templatesConfig.map(function (template) {
-        return getConfig(template);
-      }));
-    } else {
-      return getConfig(templatesConfig);
+  var getTemplateData = function (templateData, filepath, index) {
+    var data;
+    if (Array.isArray(templateData)) {
+      data = templateData[index];
+      if (data) return data;
+      grunt.log.error('You need to assign the same number of data files as source files when using array notation.');
+      return;
     }
+    if (typeof templateData === 'object') {
+      return templateData;
+    }
+    if (grunt.file.exists(templateData)) {
+      return templateData;
+    }
+    if (isGlob(templateData) !== undefined) {
+      data = filepath.replace(path.extname(filepath), path.extname(templateData));
+      if (data) return data;
+      grunt.log.error('No matching data file for '+filepath+'.');
+      return;
+    }
+    return templateData;
+  };
+
+  var getDest = function (destConfig, index) {
+    var dest;
+    if (Array.isArray(destConfig)) {
+      dest = destConfig[index];
+      if (dest) return dest;
+      grunt.log.error('You need to assign the same number of destination files as source files when using array notation.');
+      return;
+    }
+    if (isGlob(destConfig) !== undefined) {
+      dest = grunt.file.expand(destConfig)[index];
+      if (dest) return dest;
+      grunt.log.error('You need to assign the same number of destination files as source files when using glob notation.');
+      return;
+    }
+    return destConfig;
   };
 
   grunt.registerMultiTask('compile-handlebars', 'Compile Handlebars templates ', function() {
     var fs = require('fs');
     var path = require('path');
+    var files = this.files;
     var config = this.data;
-    var templates = getTemplates(config.template);
-    var templateData = config.templateData;
     var helpers = getConfig(config.helpers);
     var partials = getConfig(config.partials);
-    var outputInInput = config.outputInInput === true;
     var done = this.async();
 
     handlebarsPath = config.handlebars ? path.resolve(config.handlebars) : 'handlebars';
@@ -166,7 +194,7 @@ module.exports = function(grunt) {
         // just the file's name
           getBasename(helper, config.helpers);
 
-      if (handlebars.helpers[name] && usedHelpers.indexOf(fullPath) == -1) {
+      if (handlebars.helpers[name] && usedHelpers.indexOf(fullPath) === -1) {
         grunt.log.error(name + ' is already registered, clobbering with the new value. Consider setting `registerFullPath` to true');
       } else {
         usedHelpers.push(fullPath);
@@ -183,7 +211,7 @@ module.exports = function(grunt) {
         // just the file's name
           getBasename(partial, config.partials);
 
-      if (handlebars.partials[name] && usedPartials.indexOf(fullPath) == -1) {
+      if (handlebars.partials[name] && usedPartials.indexOf(fullPath) === -1) {
         grunt.log.error(name + ' is already registered, clobbering with the new value. Consider setting `registerFullPath` to true');
       } else {
         usedPartials.push(fullPath);
@@ -192,26 +220,29 @@ module.exports = function(grunt) {
       handlebars.registerPartial(name, fs.readFileSync(fs.realpathSync(partial), "utf8"));
     });
 
-    templates.forEach(function(template, index) {
+    var doCompilation = function (file, filepath, index) {
+      var dest = file.dest || "";
+      var template = filepath;
       var compiledTemplate = handlebars.compile(parseData(template, true));
-      var basename = getBasename(template, config.template);
-      var outputBasename = getBasename(template, config.template, outputInInput);
-      var outputPath = getName(config.output, basename, index);
-      var appendToFile = (index !== 0) && (Array.isArray(config.template) || !!isGlob(config.template)) && (config.output === outputPath);
+      var templateData = getTemplateData(config.templateData, filepath, index);
+      var basename = path.basename(template);
+      var outputPath = getDest(dest, index);
+      var appendToFile = ( outputPath === file.orig.dest && grunt.file.exists(outputPath));
       var operation = appendToFile ? 'appendFileSync' : 'writeFileSync';
       var html = '';
       var json;
 
       if (config.preHTML) {
-        html += parseData(getName(config.preHTML, basename, index));
+        html += parseData(config.preHTML);
       }
 
       json = mergeJson(parseData(getName(templateData, basename, index)), config.globals || []);
 
+
       html += compiledTemplate(json);
 
       if (config.postHTML) {
-        html += parseData(getName(config.postHTML, basename, index));
+        html += parseData(config.postHTML);
       }
 
 
@@ -220,13 +251,28 @@ module.exports = function(grunt) {
       grunt.file.mkdir(path.dirname(outputPath));
 
       try {
-        fs[operation](getName(config.output, outputBasename, index), html);
+        fs[operation](outputPath, html);
         grunt.verbose.ok();
         return true;
       } catch(e) {
         grunt.verbose.error();
         throw grunt.util.error('Unable to write "' + outputPath + '" file (Error code: ' + e.code + ').', e);
       }
+
+    };
+
+    files.forEach(function (file) {
+
+      if(file.src.length > 0) {
+        file.src.forEach(function (filepath, index) {
+          doCompilation(file, filepath, index);
+        });
+      } else {
+        file.orig.src.forEach(function (template, index) {
+          doCompilation(file, template, index);
+        });
+      }
+
     });
 
     process.nextTick(done);

--- a/test/compile_handlebars_test.js
+++ b/test/compile_handlebars_test.js
@@ -13,16 +13,6 @@ exports.clean = {
 
     test.done();
   },
-  jsonHandlebars: function(test) {
-    test.expect(1);
-
-    var actual   = grunt.file.read('tmp/sweedish.json');
-    var expected = grunt.file.read('test/expected/sweedish.json');
-
-    test.equal(actual, expected, 'json handlebars templates should work');
-
-    test.done();
-  },
   dynamicHandlebars: function(test) {
     test.expect(1);
 
@@ -30,6 +20,16 @@ exports.clean = {
     var expected = grunt.file.read('test/expected/dynamicHandlebars.html');
 
     test.equal(actual, expected, 'Passed reference to handlebars should work');
+
+    test.done();
+  },
+  jsonHandlebars: function(test) {
+    test.expect(1);
+
+    var actual   = grunt.file.read('tmp/sweedish.json');
+    var expected = grunt.file.read('test/expected/sweedish.json');
+
+    test.equal(actual, expected, 'json handlebars templates should work');
 
     test.done();
   },
@@ -99,16 +99,6 @@ exports.clean = {
 
     test.done();
   },
-  helperAndPartial: function (test) {
-    test.expect(1);
-
-    var actual = grunt.file.read('tmp/deep/helperAndPartial.html');
-    var expected = grunt.file.read('test/expected/helperAndPartial.html');
-
-    test.equal(actual, expected, 'Helpers and partials should be corrected renderred');
-
-    test.done();
-  },
   globalJsonGlobbedTemplate: function (test) {
     test.expect(1);
 
@@ -136,6 +126,16 @@ exports.clean = {
     var expected = grunt.file.read('test/expected/concatGlobbed.html');
 
     test.equal(actual, expected, 'Globbed templates should append when output is a singlefile');
+
+    test.done();
+  },
+  helperAndPartial: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/deep/helperAndPartial.html');
+    var expected = grunt.file.read('test/expected/helperAndPartial.html');
+
+    test.equal(actual, expected, 'Helpers and partials should be corrected renderred');
 
     test.done();
   }

--- a/test/compile_handlebars_test.js
+++ b/test/compile_handlebars_test.js
@@ -125,7 +125,21 @@ exports.clean = {
     var actual = grunt.file.read('tmp/concatGlobbed.html');
     var expected = grunt.file.read('test/expected/concatGlobbed.html');
 
-    test.equal(actual, expected, 'Globbed templates should append when output is a singlefile');
+    test.equal(actual, expected, 'Globbed templates should append when output is a single file');
+
+    test.done();
+  },
+  oneTemplateToManyOutputs: function (test) {
+    test.expect(2);
+
+    var actual1 = grunt.file.read('tmp/oneTemplateToManyOutputs1.html');
+    var expected1 = grunt.file.read('test/expected/oneTemplateToManyOutputs1.html');
+
+    var actual2 = grunt.file.read('tmp/oneTemplateToManyOutputs2.html');
+    var expected2= grunt.file.read('test/expected/oneTemplateToManyOutputs2.html');
+
+    test.equal(actual1, expected1, 'Output should use same template but different data when it is a single file');
+    test.equal(actual2, expected2, 'Output should use same template but different data when it is a single file');
 
     test.done();
   },

--- a/test/expected/dynamicPost.html
+++ b/test/expected/dynamicPost.html
@@ -1,2 +1,2 @@
 <h1>Hello, World</h1>
-<footer>INLINE HEADER</footer>
+<footer>INLINE FOOTER</footer>

--- a/test/expected/oneTemplateToManyOutputs1.html
+++ b/test/expected/oneTemplateToManyOutputs1.html
@@ -1,0 +1,1 @@
+<h1>Hello, World</h1>

--- a/test/expected/oneTemplateToManyOutputs2.html
+++ b/test/expected/oneTemplateToManyOutputs2.html
@@ -1,0 +1,1 @@
+<h1>Hallo, Welt</h1>

--- a/test/fixtures/oneTemplateToManyOutputs1.json
+++ b/test/fixtures/oneTemplateToManyOutputs1.json
@@ -1,0 +1,5 @@
+{
+  "salutation": "Hello",
+  "punctuation": ",",
+  "location": "World"
+}

--- a/test/fixtures/oneTemplateToManyOutputs2.json
+++ b/test/fixtures/oneTemplateToManyOutputs2.json
@@ -1,0 +1,5 @@
+{
+  "salutation": "Hallo",
+  "punctuation": ",",
+  "location": "Welt"
+}


### PR DESCRIPTION
Okay so this ended up being quite a major rewrite, but here's are the changes:

* The task now uses the grunt file object instead of `template` and `output` options. This is more familiar to Grunt users and offloads some of the tricky normalization to Grunt itself.
* Removed the `outputInInput` option, as this functionality is provided by the change listed above.
* The task now supports one (and only one) template being output to multiple destination files. (#46)

I've added tests and updated the README to reflect the changes. Let me know if there's anything you'd like to discuss,