### PR TITLE
replace encoded link characters from JSON content

### DIFF
--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -198,6 +198,8 @@ module.exports = function(grunt) {
         html += parseData(getName(config.postHTML, basename, index));
       }
 
+      html = html.replace(/\&lt;a/g, '<a').replace(/\href=&#x27;/g, 'href="').replace(/\&#x27;&gt;/g, '">').replace(/\&lt;/g, '<').replace(/\&gt;/g, '>');
+
       grunt.file.write(getName(config.output, outputBasename, index), html);
     });
 


### PR DESCRIPTION
If JSON content contains inline links the characters are encoded so I've replaced the characters to allow HTML links in the final output.