### PR TITLE
Use version 2 of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "dependencies": {
     "alce": "^1.0.0",
     "handlebars": ">= 1",
-    "lodash.merge": ">= 2",
-    "lodash.toarray": ">=2"
+    "lodash.merge": "^3.0.0",
+    "lodash.toarray": "^3.0.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Lodash has come with a version that does not work any more if you do a clean npm install of grunt-compile-handlers. I am not totally sure this is what you want but I do know the installation works :)