### PR TITLE
Add ability to have a function be templateData

### DIFF
--- a/tasks/compile-handlebars.js
+++ b/tasks/compile-handlebars.js
@@ -125,6 +125,9 @@ module.exports = function(grunt) {
 
   var getTemplateData = function(templateData, filepath, index) {
     var data;
+    if (typeof templateData === 'function') {
+      return getTemplateData(templateData(), filepath, index);
+    }
     if (Array.isArray(templateData)) {
       data = templateData[index];
       if (data) {


### PR DESCRIPTION
This is useful if you want to use something dynamically generated during the build process and want to somehow do something with that. Here's an example: 

```
        templateData: function () {
          var envConfig = require('./client/config/json/environment.json');
          return {
            version: version,
            env: envConfig.environment,
            commitHash: envConfig.commitHash,
            commitTime: envConfig.commitTime,
            apiHost: envConfig.host
          };
        },
```

Would be happy to add tests/documentation/w/e else is needed if you're interested in adding this in.
