### PR TITLE
Update lodash to fix critical security vulnerability: CVE-2019-10744

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "dependencies": {
     "alce": "^1.0.0",
     "handlebars": ">= 1",
-    "lodash.merge": "^3.0.0",
-    "lodash.toarray": "^3.0.0"
+    "lodash.merge": "^4.0.0",
+    "lodash.toarray": "^4.0.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Simple upgrade to v4 of lodash to fix a [critical security vulnerability](https://github.com/advisories/GHSA-jf85-cpcp-j695)

npm made me aware of this by running `npm audit` on a project of mine that depends on this package.

I'm sure many others using this package would benefit from this upgrade, hence making a PR.